### PR TITLE
Fix CI task - lock numpy below V2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-numpy
+numpy<2
 pydantic<2.0
 pandas
 pyyaml


### PR DESCRIPTION
# Pull Request

## Description

This should fix the failing CI task. Meanwhile I can look into upgrading this repo to numpy 2.0 too. 

Fixes #77 

## How Has This Been Tested?

CI tests have been run on my fork. The only part that failed was the coverage report upload.

- [x] Yes

## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings
