### PR TITLE
Upgrade numpy, pydantic and nowcasting_datamodel

### DIFF
--- a/gspconsumer/app.py
+++ b/gspconsumer/app.py
@@ -205,7 +205,7 @@ def pull_data_and_save(
             # need columns datetime_utc, solar_generation_kw
             gsp_yield_df["solar_generation_kw"] = 1000 * gsp_yield_df["generation_mw"]
             gsp_yield_df["datetime_utc"] = gsp_yield_df["datetime_gmt"]
-            gsp_yield_df["pvlive_updated_utc"] = gsp_yield_df["updated_gmt"]
+            gsp_yield_df["pvlive_updated_utc"] = pd.to_datetime(gsp_yield_df["updated_gmt"])
             gsp_yield_df = gsp_yield_df[
                 [
                     "solar_generation_kw",

--- a/gspconsumer/app.py
+++ b/gspconsumer/app.py
@@ -228,7 +228,7 @@ def pull_data_and_save(
             # update installed capacity
             if len(gsp_yield_df) > 0:
                 current_installed_capacity = gsp_yield_sql.location.installed_capacity_mw
-                new_installed_capacity = gsp_yield_df["installedcapacity_mwp"].iloc[0]
+                new_installed_capacity = float(gsp_yield_df["installedcapacity_mwp"].iloc[0])
                 if current_installed_capacity != new_installed_capacity:
                     logger.debug(
                         f"Going to update the capacity from "

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,9 @@
 numpy
-pydantic<2.0
+pydantic
 pandas
 pyyaml
 urllib3
 requests
-nowcasting_datamodel==1.4.6
+nowcasting_datamodel==1.5.46
 #git+https://github.com/SheffieldSolar/PV_Live-API#pvlive_api
 click

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-numpy
-pydantic
+numpy>2
+pydantic>2
 pandas
 pyyaml
 urllib3

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-numpy>2
-pydantic>2
+numpy>=2
+pydantic>=2
 pandas
 pyyaml
 urllib3


### PR DESCRIPTION
# Pull Request

## Description

- Updates `nowcasting_datamodel` to the latest version, which requires numpy 2.
- The new `nowcasting_datamodel` version also has a higher `pydantic` requirement so that needed to be bumped.
- Fixed the float64 issue which was similar to the issue in the datamodel repo and required a cast to a python float.
- Converted a column to a datetime as it was failing validation when the data was converted to a pydantic object.

Fixes #77 

This supersedes the other PR (#78) that I rasied.

## How Has This Been Tested?

Ran test suite locally.

- [x] Yes

## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings
