### PR TITLE
Join 3 gsps

### DIFF
--- a/pvliveconsumer/app.py
+++ b/pvliveconsumer/app.py
@@ -44,6 +44,13 @@ pvlive_domain_url = os.getenv("PVLIVE_DOMAIN_URL", "api.pvlive.uk")
 # ignore these gsp ids from PVLive as they are no longer used
 ignore_gsp_ids = [5, 17, 53, 75, 139, 140, 143, 157, 163, 225, 310]
 
+# These GSPs have been split, as part of PVLive update  20251204
+# To make this backwards compatible, we need to also save values for
+# IVER_1|IVER_6 158,
+# BRLE_1|FLEE_1 41
+# SEAB1|SAFO_1 257
+split_gsp_ids = {41 : [343,344], 158 : [345,346],  257 : [347,348]}
+    
 
 @click.command()
 @click.option(
@@ -173,17 +180,38 @@ def pull_data_and_save(
 
     all_gsps_yields_sql = []
     for gsp in gsps:
+
         if gsp.gsp_id in ignore_gsp_ids:
             continue
 
-        gsp_yield_df: pd.DataFrame = pvlive.between(
-            start=start,
-            end=end,
-            entity_type="gsp",
-            entity_id=gsp.gsp_id,
-            dataframe=True,
-            extra_fields="installedcapacity_mwp,capacity_mwp,updated_gmt",
-        )
+        if gsp.gsp_id in split_gsp_ids:
+            logger.info(f"Summing up GSP ID {gsp.gsp_id} from gsp ids {split_gsp_ids[gsp.gsp_id]} parts")
+            gsp_ids = split_gsp_ids[gsp.gsp_id]
+            gsp_yield_dfs = []
+            for gsp_id in gsp_ids:
+                gsp_yield_df = pvlive.between(
+                    start=start,
+                    end=end,
+                    entity_type="gsp",
+                    entity_id=gsp_id,
+                    dataframe=True,
+                    extra_fields="installedcapacity_mwp,capacity_mwp,updated_gmt",
+                )
+                gsp_yield_dfs.append(gsp_yield_df)
+            gsp_yield_df = pd.concat(gsp_yield_dfs)
+            # sum up all these values
+            gsp_yield_df = gsp_yield_df.groupby("datetime_gmt").sum().reset_index()
+            gsp_yield_df['gsp_id'] = gsp.gsp_id
+
+        else:
+            gsp_yield_df: pd.DataFrame = pvlive.between(
+                start=start,
+                end=end,
+                entity_type="gsp",
+                entity_id=gsp.gsp_id,
+                dataframe=True,
+                extra_fields="installedcapacity_mwp,capacity_mwp,updated_gmt",
+            )
 
         logger.debug(f"Processing GSP ID {gsp.gsp_id} ({gsp.label}), out of {len(gsps)}")
 

--- a/pvliveconsumer/app.py
+++ b/pvliveconsumer/app.py
@@ -19,8 +19,8 @@ from nowcasting_datamodel.connection import DatabaseConnection
 from nowcasting_datamodel.models.base import Base_Forecast
 from nowcasting_datamodel.models.gsp import GSPYield, GSPYieldSQL, LocationSQL
 from pvlive_api import PVLive
-from sqlalchemy.orm import Session
 from pvlive_api.pvlive import PVLiveException
+from sqlalchemy.orm import Session
 
 import pvliveconsumer
 from pvliveconsumer.backup import make_gsp_yields_from_national
@@ -182,7 +182,6 @@ def pull_data_and_save(
 
     all_gsps_yields_sql = []
     for gsp in gsps:
-
         if gsp.gsp_id in ignore_gsp_ids:
             continue
 
@@ -197,7 +196,9 @@ def pull_data_and_save(
             )
         except PVLiveException as e:
             if gsp.gsp_id in split_gsp_ids:
-                logger.info(f"Summing up GSP ID {gsp.gsp_id} from gsp ids {split_gsp_ids[gsp.gsp_id]} parts")
+                logger.info(
+                    f"Summing up GSP ID {gsp.gsp_id} from gsp ids {split_gsp_ids[gsp.gsp_id]} parts"
+                )
                 gsp_ids = split_gsp_ids[gsp.gsp_id]
                 gsp_yield_dfs = []
                 for gsp_id in gsp_ids:
@@ -213,7 +214,7 @@ def pull_data_and_save(
                 gsp_yield_all_df = pd.concat(gsp_yield_dfs)
                 # sum up all these values
                 gsp_yield_df = gsp_yield_all_df.groupby("datetime_gmt").sum().reset_index()
-                gsp_yield_df['gsp_id'] = gsp.gsp_id
+                gsp_yield_df["gsp_id"] = gsp.gsp_id
                 gsp_yield_df["updated_gmt"] = gsp_yield_dfs[0]["updated_gmt"]
             else:
                 raise e

--- a/pvliveconsumer/app.py
+++ b/pvliveconsumer/app.py
@@ -50,7 +50,8 @@ ignore_gsp_ids = [5, 17, 53, 75, 139, 140, 143, 157, 163, 225, 310]
 # IVER_1|IVER_6 158,
 # BRLE_1|FLEE_1 41
 # SEAB1|SAFO_1 257
-# Note that once, the platform doesnt need these old gsp ids, then we can put them into the ignore list
+# Note that once, the platform doesnt need these old gsp ids,
+# then we can put them into the ignore list
 split_gsp_ids = {41: [343, 344], 158: [345, 346], 257: [347, 348]}
 
 

--- a/pvliveconsumer/app.py
+++ b/pvliveconsumer/app.py
@@ -20,6 +20,7 @@ from nowcasting_datamodel.models.base import Base_Forecast
 from nowcasting_datamodel.models.gsp import GSPYield, GSPYieldSQL, LocationSQL
 from pvlive_api import PVLive
 from sqlalchemy.orm import Session
+from pvlive_api.pvlive import PVLiveException
 
 import pvliveconsumer
 from pvliveconsumer.backup import make_gsp_yields_from_national
@@ -44,13 +45,14 @@ pvlive_domain_url = os.getenv("PVLIVE_DOMAIN_URL", "api.pvlive.uk")
 # ignore these gsp ids from PVLive as they are no longer used
 ignore_gsp_ids = [5, 17, 53, 75, 139, 140, 143, 157, 163, 225, 310]
 
-# These GSPs have been split, as part of PVLive update  20251204
+# These GSPs have been split, as part of PVLive update 20251204
 # To make this backwards compatible, we need to also save values for
 # IVER_1|IVER_6 158,
 # BRLE_1|FLEE_1 41
 # SEAB1|SAFO_1 257
-split_gsp_ids = {41 : [343,344], 158 : [345,346],  257 : [347,348]}
-    
+# Note that once, the platform doesnt need these old gsp ids, then we can put them into the ignore list
+split_gsp_ids = {41: [343, 344], 158: [345, 346], 257: [347, 348]}
+
 
 @click.command()
 @click.option(
@@ -184,26 +186,7 @@ def pull_data_and_save(
         if gsp.gsp_id in ignore_gsp_ids:
             continue
 
-        if gsp.gsp_id in split_gsp_ids:
-            logger.info(f"Summing up GSP ID {gsp.gsp_id} from gsp ids {split_gsp_ids[gsp.gsp_id]} parts")
-            gsp_ids = split_gsp_ids[gsp.gsp_id]
-            gsp_yield_dfs = []
-            for gsp_id in gsp_ids:
-                gsp_yield_df = pvlive.between(
-                    start=start,
-                    end=end,
-                    entity_type="gsp",
-                    entity_id=gsp_id,
-                    dataframe=True,
-                    extra_fields="installedcapacity_mwp,capacity_mwp,updated_gmt",
-                )
-                gsp_yield_dfs.append(gsp_yield_df)
-            gsp_yield_df = pd.concat(gsp_yield_dfs)
-            # sum up all these values
-            gsp_yield_df = gsp_yield_df.groupby("datetime_gmt").sum().reset_index()
-            gsp_yield_df['gsp_id'] = gsp.gsp_id
-
-        else:
+        try:
             gsp_yield_df: pd.DataFrame = pvlive.between(
                 start=start,
                 end=end,
@@ -212,6 +195,28 @@ def pull_data_and_save(
                 dataframe=True,
                 extra_fields="installedcapacity_mwp,capacity_mwp,updated_gmt",
             )
+        except PVLiveException as e:
+            if gsp.gsp_id in split_gsp_ids:
+                logger.info(f"Summing up GSP ID {gsp.gsp_id} from gsp ids {split_gsp_ids[gsp.gsp_id]} parts")
+                gsp_ids = split_gsp_ids[gsp.gsp_id]
+                gsp_yield_dfs = []
+                for gsp_id in gsp_ids:
+                    gsp_yield_df = pvlive.between(
+                        start=start,
+                        end=end,
+                        entity_type="gsp",
+                        entity_id=gsp_id,
+                        dataframe=True,
+                        extra_fields="installedcapacity_mwp,capacity_mwp,updated_gmt",
+                    )
+                    gsp_yield_dfs.append(gsp_yield_df)
+                gsp_yield_all_df = pd.concat(gsp_yield_dfs)
+                # sum up all these values
+                gsp_yield_df = gsp_yield_all_df.groupby("datetime_gmt").sum().reset_index()
+                gsp_yield_df['gsp_id'] = gsp.gsp_id
+                gsp_yield_df["updated_gmt"] = gsp_yield_dfs[0]["updated_gmt"]
+            else:
+                raise e
 
         logger.debug(f"Processing GSP ID {gsp.gsp_id} ({gsp.label}), out of {len(gsps)}")
 


### PR DESCRIPTION
# Pull Request

## Description

The updates from 20251204 - https://www.neso.energy/data-portal/gis-boundaries-gb-grid-supply-points.
This means gsp_ids 41, 158 and 257 will not have nay data available.

We backfill these gsp ids by adding the corresponding gsp_ids together 

Fixes https://github.com/openclimatefix/pvlive-consumer/issues/108

Note we want to be able to deploy this before the deployment change has taken place

## How Has This Been Tested?

- [x] Ci tests
- [x] ran locally on `api0.solar.sheffield.ac.uk`

## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings
